### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/lib/src/main/res/layout/directory_chooser.xml
+++ b/lib/src/main/res/layout/directory_chooser.xml
@@ -1,83 +1,72 @@
-<?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+<?xml version='1.0' encoding='utf-8'?>
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical">
 
-    <LinearLayout
-        android:layout_width="match_parent"
+  <LinearLayout android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal">
+
+    <ImageButton android:id="@+id/btn_nav_up"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:background="?android:attr/selectableItemBackground"
+      android:contentDescription="@string/up"
+      android:padding="16dp"
+      android:src="@drawable/navigation_up"/>
+
+    <LinearLayout android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_vertical"
+      android:layout_weight="1"
+      android:orientation="vertical">
+
+      <TextView android:id="@+id/txt_selected_folder_label"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:text="@string/selected_folder"
+        android:textStyle="bold"/>
 
-        <ImageButton
-            android:id="@+id/btn_nav_up"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="?android:attr/selectableItemBackground"
-            android:contentDescription="@string/up"
-            android:padding="16dp"
-            android:src="@drawable/navigation_up" />
-
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_weight="1"
-            android:orientation="vertical">
-
-            <TextView
-                android:id="@+id/txt_selected_folder_label"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/selected_folder"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/txt_selected_folder"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="5dp"
-                android:ellipsize="start"
-                android:scrollHorizontally="true"
-                android:singleLine="true"
-                android:text="test" />
-
-        </LinearLayout>
-
-        <ImageButton
-            android:id="@+id/btn_create_folder"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentTop="true"
-            android:background="?android:attr/selectableItemBackground"
-            android:contentDescription="@string/create_folder"
-            android:padding="16dp"
-            android:src="@drawable/ic_action_create" />
-
+      <TextView android:id="@+id/txt_selected_folder"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:ellipsize="start"
+        android:scrollHorizontally="true"
+        android:singleLine="true"
+        android:text="test"/>
     </LinearLayout>
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/android_bright_blue" />
+    <ImageButton android:id="@+id/btn_create_folder"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:background="?android:attr/selectableItemBackground"
+      android:contentDescription="@string/create_folder"
+      android:padding="16dp"
+      android:src="@drawable/ic_action_create">
+      <!--Removed ObsoleteLayoutParam: layout_alignParentRight-->
+      <!--Removed ObsoleteLayoutParam: layout_alignParentTop-->
+    </ImageButton>
+  </LinearLayout>
 
-    <ListView
-        android:id="@+id/list_dirs"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:listitem="@android:layout/simple_list_item_1" />
+  <View android:layout_width="match_parent"
+    android:layout_height="1dp"
+    android:background="@color/android_bright_blue"/>
 
-    <TextView
-        android:id="@+id/txt_list_empty"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:alpha="0.5"
-        android:gravity="center"
-        android:padding="10dp"
-        android:text="@string/empty_list"
-        android:textSize="30sp"
-        android:visibility="gone" />
+  <ListView android:id="@+id/list_dirs"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:listitem="@android:layout/simple_list_item_1"/>
 
+  <TextView android:id="@+id/txt_list_empty"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:alpha="0.5"
+    android:gravity="center"
+    android:padding="10dp"
+    android:text="@string/empty_list"
+    android:textSize="30sp"
+    android:visibility="gone"/>
 </LinearLayout>


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis